### PR TITLE
feat: add support for the rich text editor

### DIFF
--- a/src/codePerfect.css
+++ b/src/codePerfect.css
@@ -1,5 +1,6 @@
 pre.hljs code {
     font-family: Consolas, Source Code Pro, DejaVu Sans Mono, Ubuntu Mono, Anonymous Pro, Droid Sans Mono, Menlo, Monaco, Inconsolata, Courier, monospace, PingFang SC, Microsoft YaHei, sans-serif;
+    padding: 1em !important;
 }
 
 pre.hljs {

--- a/src/codePerfect.css
+++ b/src/codePerfect.css
@@ -1,5 +1,8 @@
-pre.hljs code {
+pre.hljs code, ul.hljs {
     font-family: Consolas, Source Code Pro, DejaVu Sans Mono, Ubuntu Mono, Anonymous Pro, Droid Sans Mono, Menlo, Monaco, Inconsolata, Courier, monospace, PingFang SC, Microsoft YaHei, sans-serif;
+}
+
+pre.hljs code {
     padding: 1em !important;
 }
 
@@ -10,7 +13,7 @@ pre.hljs {
     font-size: 16px;
 }
 
-pre ul.hljs-line-num {
+ul.hljs-line-num {
     position: absolute;
     left: 0;
     top: 0;
@@ -26,7 +29,7 @@ pre ul.hljs-line-num {
     box-sizing: border-box;
 }
 
-pre ul.hljs-line-num li {
+ul.hljs-line-num li {
     margin: 0;
     padding: 0;
 }

--- a/src/codePerfect.ts
+++ b/src/codePerfect.ts
@@ -48,7 +48,7 @@ module.exports = {
                     Array.from(preElems).forEach((item, index) => {
                         let num = item.innerHTML.split('\n').length - 1
                         let ul = document.createElement("ul")
-                        ul.setAttribute('class', 'hljs-line-num')
+                        ul.setAttribute('class', 'hljs hljs-line-num')
                         for (let i = 0; i < num; i++) {
                             let n = i + 1
                             let childLi = document.createElement("li")

--- a/src/codePerfect.ts
+++ b/src/codePerfect.ts
@@ -43,7 +43,6 @@ module.exports = {
 
                     // 行号
                     const codePerfectContainerElement = document.createElement("div");
-                    codePerfectContainerElement.classList.add("code-perfect-container");
                     codePerfectContainerElement.innerHTML = `${defaultRender(tokens, idx, options, env, self)} ${button}`;
                     const preElems = codePerfectContainerElement.querySelectorAll("pre.hljs");
                     Array.from(preElems).forEach((item, index) => {
@@ -64,14 +63,22 @@ module.exports = {
                     // const foldElem = document.createElement("div");
                     // foldElem.classList.add("code-perfect-fold-button");
 
-                    return codePerfectContainerElement.outerHTML;
+                    const escapeHtml = markdownIt.utils.escapeHtml;
+                    const language = escapeHtml(token.info).split(/\s+/g)[0];
+                    const source = `${token.markup}${escapeHtml(token.info)}&NewLine;`
+
+                    return `
+                        <div class="joplin-editable code-perfect-container">
+                            <pre
+                                class="joplin-source"
+                                data-joplin-language="${language}"
+                                data-joplin-source-open="${source}"
+                                data-joplin-source-close="${token.markup}"
+                            >${escapeHtml(token.content)}</pre>
+                            ${codePerfectContainerElement.innerHTML}
+                        </div>
+                    `;
                 }
-            },
-            assets: function () {
-                return [
-                    {name: 'highlight/styles/atom-one-dark.css'},
-                    {name: 'codePerfect.css'}
-                ];
             },
         }
     }

--- a/src/index.ts
+++ b/src/index.ts
@@ -34,5 +34,10 @@ joplin.plugins.register({
         await joplin.contentScripts.onMessage(pluginId, (message: any) => {
             joplin.clipboard.writeText(decodeURIComponent(message));
         });
+
+        const installDir = await joplin.plugins.installationDir();
+
+        await joplin.window.loadNoteCssFile(`${installDir}/highlight/styles/atom-one-dark.css`);
+        await joplin.window.loadNoteCssFile(`${installDir}/codePerfect.css`);
     },
 });


### PR DESCRIPTION
This PR adds support for the rich text editor. 

Wrapped the container element in a .joplin-editable container to[ enable rich text editor support.](https://joplinapp.org/api/references/plugin_api/enums/contentscripttype.html#supporting-the-rich-text-editor)

When CSS files were loaded as markdownIt assets they wern't available in the rich text editor. Loading files using [joplin.window.loadNoteCssFile](https://joplinapp.org/api/references/plugin_api/classes/joplinwindow.html) made the styles avaliable in both views.

![Joplin_7JIaTCpBIr](https://github.com/user-attachments/assets/172a3068-067d-4d3c-b34a-8776306f35bc)

![Joplin_o7SA2Meg5F](https://github.com/user-attachments/assets/3c5b75e9-93e7-41f9-a769-72f7105fabc0)

fixes #4